### PR TITLE
remove experimental flags for ros extensions

### DIFF
--- a/.github/workflows/example_snap_github_action.yaml
+++ b/.github/workflows/example_snap_github_action.yaml
@@ -23,9 +23,6 @@ jobs:
       with:
         # Select the example we want to build
         path: 'github_action'
-      env:
-        # Enable experimental extensions for the ros2-humble extension
-        SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: 1
 
     # Make sure the snap is installable
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,6 @@ jobs:
           # Select the example we want to build
           path: "${{ matrix.dir }}"
           snapcraft-channel: 'stable'
-        env:
-          SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: 1
 
       # Make sure the snap is installable
       - run: sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}

--- a/orchestration_humble_core22/README.md
+++ b/orchestration_humble_core22/README.md
@@ -7,7 +7,7 @@ Make sure [`snapd`](https://snapcraft.io/docs/installing-snapd) and [`snapcraft`
 
 Then at the root of this file:
 
-`SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft`
+`snapcraft`
 
 `sudo snap install talker-listener_0.1_amd64.snap --dangerous`
 

--- a/rosinstall_noetic_core20/README.md
+++ b/rosinstall_noetic_core20/README.md
@@ -4,7 +4,7 @@ ROS (Noetic) package, packed as a snap
 The source of this package are listed in a `.rosinstall` file. By the mean of [`vcstools`](https://github.com/dirk-thomas/vcstool) we show how to leverage `.rosinstall` to retreive source when building a snap.
 
 ## How to generate the snap
-- `snapcraft --enable-experimental-extensions`
+- `snapcraft`
 ## How to install the snap
 - `sudo snap install snapped-ros1-pkg*.snap --dangerous`
 ## How to run the snap

--- a/source_pkg_foxy_core20/README.md
+++ b/source_pkg_foxy_core20/README.md
@@ -3,7 +3,7 @@ ROS 2 Foxy package, packed as a snap.
 
 The ROS package contains a node that simply publishes a `geometry_msgs::msg::Twist` on `fake_pose` containing random data.
 ## How to generate the snap
-- `snapcraft --enable-experimental-extensions`
+- `snapcraft`
 ## How to install the snap
 - `sudo snap install snapped-ros2-pkg*.snap --dangerous`
 ## How to run the snap

--- a/source_pkg_humble_core22/README.md
+++ b/source_pkg_humble_core22/README.md
@@ -3,7 +3,7 @@ ROS 2 Humble package, packed as a snap.
 
 The ROS package contains a node that simply publishes a `geometry_msgs::msg::Twist` on `fake_pose` containing random data.
 ## How to generate the snap
-- `SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1 snapcraft`
+- `snapcraft`
 ## How to install the snap
 - `sudo snap install snapped-ros2-pkg*.snap --dangerous`
 ## How to run the snap

--- a/source_pkg_noetic_core20/README.md
+++ b/source_pkg_noetic_core20/README.md
@@ -3,7 +3,7 @@ ROS 1 (Noetic) package, packed as a snap
 
 The ros package contains a node that simply publishes a `geometry_msgs::Twist` on `fake_pose` containing random data.
 ## How to generate the snap
-- `snapcraft --enable-experimental-extensions`
+- `snapcraft`
 ## How to install the snap
 - `sudo snap install snapped-ros1-pkg*.snap --dangerous`
 ## How to run the snap


### PR DESCRIPTION
Remove experimental flags from ros extensions examples, since it's not required in the newest version of Snapcraft