### PR TITLE
Do not double stage bash, zsh and ps1 scripts

### DIFF
--- a/shared_memory_foxy_core20/disable-shared-memory-compile-time/snap/snapcraft.yaml
+++ b/shared_memory_foxy_core20/disable-shared-memory-compile-time/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
     source-subdir: demo_nodes_cpp
     stage-packages: [ros-foxy-ros2launch]
     stage:
-            - -opt/ros/snap/*setup.sh
+      - -opt/ros/snap/*setup.*
 
 apps:
   ros2-talker-listener:


### PR DESCRIPTION
Before we were simply not double staging the `sh` scripts from the two parts.
Now our second part is also trying to stage `bash`, `zsh` and `ps1` script that were already staged by the `fastdds`.

This should fix the CI