### PR TITLE
fix(ci): migrate to github action v4 since v3 is deprecated

### DIFF
--- a/.github/workflows/example_snap_github_action.yaml
+++ b/.github/workflows/example_snap_github_action.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: snapcore/action-build@v1
       id: build-snap
       with:
@@ -30,7 +30,7 @@ jobs:
     # Do some testing with the snap
     - run: |
         ros2-humble-talker-listener --print
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ros2-snap
         path: ${{ steps.build-snap.outputs.snap }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ros2-snap
         path: .

--- a/.github/workflows/private_code_snap_github_action.yaml
+++ b/.github/workflows/private_code_snap_github_action.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Create ~/.ssh
       run: |
         mkdir ~/.ssh
@@ -39,7 +39,7 @@ jobs:
     # Do some testing with the snap
     - run: |
         snap-with-private-source
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: private_code_snap
         path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       dirs: ${{ steps.dirs.outputs.dirs }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: dirs
         run: echo "dirs=$(find . -type f -name 'snapcraft.yaml' | sed -r 's|\/snap/[^/]+$||' |sort |uniq |jq --raw-input --slurp --compact-output 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
@@ -34,7 +34,7 @@ jobs:
          - dir: "./github_action_private_source/snapcraft.yaml"
     name: "Snap ${{ matrix.dir }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
         id: build-snap
         with:
@@ -49,7 +49,7 @@ jobs:
       # - run: ros2-shared-memory.ros2-talker-listener --print
 
       # @todo set unique artifact or snap names
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: snaps


### PR DESCRIPTION
Migrate to the new GH actions since the previous ones are now deprecated: https://github.com/ubuntu-robotics/ros-snaps-examples/actions/runs/13083638216