### PR TITLE
[hermes-agent] feat: add ROS 2 humble/jazzy content-sharing talker-listener examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
         id: build-snap
+        env:
+          SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: 1
         with:
           # Select the example we want to build
           path: "${{ matrix.dir }}"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This repository hold examples used in documentation and blogposts.
 - [shared_memory_foxy_core20](./shared_memory_foxy_core20/README.md) - Leverage shared memory feature of ROS 2 in snaps.
 - [source_pkg_dashing_core18](./source_pkg_dashing_core18/README.md) - Snap a ROS 2 Dashing package from source on core18.
 - [source_pkg_foxy_core20](./source_pkg_foxy_core20/README.md) - Snap a ROS 2 Foxy package from source on core20.
+- [content_sharing_humble_core22](./content_sharing_humble_core22/README.md) - ROS 2 Humble content-sharing talker/listener using ros2-humble-ros-base.
+- [content_sharing_jazzy_core24](./content_sharing_jazzy_core24/README.md) - ROS 2 Jazzy content-sharing talker/listener using ros2-jazzy-ros-base.
 - [source_pkg_humble_core22](./source_pkg_humble_core22/README.md) - Snap a ROS 2 Humble package from source on core22.
 - [source_pkg_melodic_core18](./source_pkg_melodic_core18/README.md) - Snap a ROS Melodic package from source on core18.
 - [source_pkg_noetic_core20](./source_pkg_noetic_core20/README.md) - Snap a ROS noetic package from source on core20.

--- a/content_sharing_humble_core22/README.md
+++ b/content_sharing_humble_core22/README.md
@@ -11,4 +11,4 @@ Snapcraft's ROS 2 content-sharing extension for Humble.
 - `sudo snap install ros2-humble-cs-talker-listener_*.snap --dangerous`
 
 ## How to run the snap
-- `ros2-humble-cs-talker-listener.ros2-humble-content-sharing-talker-listener`
+- `ros2-humble-cs-talker-listener.ros2-humble-cs-talker-listener`

--- a/content_sharing_humble_core22/README.md
+++ b/content_sharing_humble_core22/README.md
@@ -1,0 +1,14 @@
+# ROS 2 Humble content-sharing talker/listener
+
+This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
+Snapcraft's ROS 2 content-sharing extension for Humble.
+
+## How to generate the snap
+- `cd snap`
+- `snapcraft`
+
+## How to install the snap
+- `sudo snap install ros2-humble-cs-talker-listener_*.snap --dangerous`
+
+## How to run the snap
+- `ros2-humble-cs-talker-listener.ros2-humble-content-sharing-talker-listener`

--- a/content_sharing_humble_core22/README.md
+++ b/content_sharing_humble_core22/README.md
@@ -4,8 +4,9 @@ This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
 snapcraft's ROS 2 content-sharing extension for Humble.
 
 ## How to generate the snap
-- `cd snap`
-- `snapcraft pack`
+```console
+snapcraft pack
+```
 
 ## How to install the snap
 - `sudo snap install ros2-humble-cs-talker-listener_*.snap --dangerous`

--- a/content_sharing_humble_core22/README.md
+++ b/content_sharing_humble_core22/README.md
@@ -1,11 +1,11 @@
 # ROS 2 Humble content-sharing talker/listener
 
 This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
-Snapcraft's ROS 2 content-sharing extension for Humble.
+snapcraft's ROS 2 content-sharing extension for Humble.
 
 ## How to generate the snap
 - `cd snap`
-- `snapcraft`
+- `snapcraft pack`
 
 ## How to install the snap
 - `sudo snap install ros2-humble-cs-talker-listener_*.snap --dangerous`

--- a/content_sharing_humble_core22/snap/snapcraft.yaml
+++ b/content_sharing_humble_core22/snap/snapcraft.yaml
@@ -19,6 +19,6 @@ parts:
 
 apps:
   ros2-humble-cs-talker-listener:
-    command: opt/ros/humble/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
+    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
     plugs: [network, network-bind]
     extensions: [ros2-humble-ros-base]

--- a/content_sharing_humble_core22/snap/snapcraft.yaml
+++ b/content_sharing_humble_core22/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: ros2-humble-cs-talker-listener
+version: '0.1'
+summary: ROS 2 Humble talker/listener with content sharing
+
+description: |
+  This example launches the ROS 2 demo_nodes_cpp talker and listener
+  using the ros2-humble-ros-base content-sharing extension.
+
+grade: devel
+confinement: strict
+base: core22
+
+parts:
+  ros-demos:
+    plugin: colcon
+    source: https://github.com/ros2/demos.git
+    source-branch: humble
+    source-subdir: demo_nodes_cpp
+
+apps:
+  ros2-humble-content-sharing-talker-listener:
+    command: opt/ros/humble/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
+    plugs: [network, network-bind]
+    extensions: [ros2-humble-ros-base]

--- a/content_sharing_humble_core22/snap/snapcraft.yaml
+++ b/content_sharing_humble_core22/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
     source-subdir: demo_nodes_cpp
 
 apps:
-  ros2-humble-content-sharing-talker-listener:
+  ros2-humble-cs-talker-listener:
     command: opt/ros/humble/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     plugs: [network, network-bind]
     extensions: [ros2-humble-ros-base]

--- a/content_sharing_jazzy_core24/README.md
+++ b/content_sharing_jazzy_core24/README.md
@@ -1,11 +1,11 @@
 # ROS 2 Jazzy content-sharing talker/listener
 
 This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
-Snapcraft's ROS 2 content-sharing extension for Jazzy.
+snapcraft's ROS 2 content-sharing extension for Jazzy.
 
 ## How to generate the snap
 - `cd snap`
-- `snapcraft`
+- `snapcraft pack`
 
 ## How to install the snap
 - `sudo snap install ros2-jazzy-cs-talker-listener_*.snap --dangerous`

--- a/content_sharing_jazzy_core24/README.md
+++ b/content_sharing_jazzy_core24/README.md
@@ -11,4 +11,4 @@ Snapcraft's ROS 2 content-sharing extension for Jazzy.
 - `sudo snap install ros2-jazzy-cs-talker-listener_*.snap --dangerous`
 
 ## How to run the snap
-- `ros2-jazzy-cs-talker-listener.ros2-jazzy-content-sharing-talker-listener`
+- `ros2-jazzy-cs-talker-listener.ros2-jazzy-cs-talker-listener`

--- a/content_sharing_jazzy_core24/README.md
+++ b/content_sharing_jazzy_core24/README.md
@@ -1,0 +1,14 @@
+# ROS 2 Jazzy content-sharing talker/listener
+
+This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
+Snapcraft's ROS 2 content-sharing extension for Jazzy.
+
+## How to generate the snap
+- `cd snap`
+- `snapcraft`
+
+## How to install the snap
+- `sudo snap install ros2-jazzy-cs-talker-listener_*.snap --dangerous`
+
+## How to run the snap
+- `ros2-jazzy-cs-talker-listener.ros2-jazzy-content-sharing-talker-listener`

--- a/content_sharing_jazzy_core24/README.md
+++ b/content_sharing_jazzy_core24/README.md
@@ -4,8 +4,9 @@ This example launches the ROS 2 `demo_nodes_cpp` talker/listener using
 snapcraft's ROS 2 content-sharing extension for Jazzy.
 
 ## How to generate the snap
-- `cd snap`
-- `snapcraft pack`
+```console
+snapcraft pack
+```
 
 ## How to install the snap
 - `sudo snap install ros2-jazzy-cs-talker-listener_*.snap --dangerous`

--- a/content_sharing_jazzy_core24/snap/snapcraft.yaml
+++ b/content_sharing_jazzy_core24/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: ros2-jazzy-cs-talker-listener
+version: '0.1'
+summary: ROS 2 Jazzy talker/listener with content sharing
+
+description: |
+  This example launches the ROS 2 demo_nodes_cpp talker and listener
+  using the ros2-jazzy-ros-base content-sharing extension.
+
+grade: devel
+confinement: strict
+base: core24
+
+parts:
+  ros-demos:
+    plugin: colcon
+    source: https://github.com/ros2/demos.git
+    source-branch: jazzy
+    source-subdir: demo_nodes_cpp
+
+apps:
+  ros2-jazzy-content-sharing-talker-listener:
+    command: opt/ros/jazzy/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
+    plugs: [network, network-bind]
+    extensions: [ros2-jazzy-ros-base]

--- a/content_sharing_jazzy_core24/snap/snapcraft.yaml
+++ b/content_sharing_jazzy_core24/snap/snapcraft.yaml
@@ -19,6 +19,6 @@ parts:
 
 apps:
   ros2-jazzy-cs-talker-listener:
-    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+    command: ros2 launch demo_nodes_cpp talker_listener_launch.py
     plugs: [network, network-bind]
     extensions: [ros2-jazzy-ros-base]

--- a/content_sharing_jazzy_core24/snap/snapcraft.yaml
+++ b/content_sharing_jazzy_core24/snap/snapcraft.yaml
@@ -19,6 +19,6 @@ parts:
 
 apps:
   ros2-jazzy-cs-talker-listener:
-    command: opt/ros/jazzy/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
+    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
     plugs: [network, network-bind]
     extensions: [ros2-jazzy-ros-base]

--- a/content_sharing_jazzy_core24/snap/snapcraft.yaml
+++ b/content_sharing_jazzy_core24/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
     source-subdir: demo_nodes_cpp
 
 apps:
-  ros2-jazzy-content-sharing-talker-listener:
+  ros2-jazzy-cs-talker-listener:
     command: opt/ros/jazzy/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     plugs: [network, network-bind]
     extensions: [ros2-jazzy-ros-base]


### PR DESCRIPTION
[hermes-agent]

## Summary
- adds a ROS 2 Humble content-sharing example at `content_sharing_humble_core22/`
- adds a ROS 2 Jazzy content-sharing example at `content_sharing_jazzy_core24/`
- both examples use the ROS 2 demo `talker_listener.launch.py` from `demo_nodes_cpp`
- both examples use ROS 2 content-sharing extensions (`ros2-humble-ros-base` and `ros2-jazzy-ros-base`)
- updates top-level `README.md` example list

## Scope constraints applied
- only ROS 2 **Humble** and **Jazzy** are covered
- no additional distro content-sharing examples were added

## Test plan
- validate both new example directories contain `snap/snapcraft.yaml` and `README.md`
- verify extensions are set to:
  - `extensions: [ros2-humble-ros-base]`
  - `extensions: [ros2-jazzy-ros-base]`

Closes #23
