### PR TITLE
[hermes-agent] feat: add source_pkg_jazzy_core24 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository hold examples used in documentation and blogposts.
 - [source_pkg_dashing_core18](./source_pkg_dashing_core18/README.md) - Snap a ROS 2 Dashing package from source on core18.
 - [source_pkg_foxy_core20](./source_pkg_foxy_core20/README.md) - Snap a ROS 2 Foxy package from source on core20.
 - [source_pkg_humble_core22](./source_pkg_humble_core22/README.md) - Snap a ROS 2 Humble package from source on core22.
+- [source_pkg_jazzy_core24](./source_pkg_jazzy_core24/README.md) - Snap a ROS 2 Jazzy package from source on core24.
 - [source_pkg_melodic_core18](./source_pkg_melodic_core18/README.md) - Snap a ROS Melodic package from source on core18.
 - [source_pkg_noetic_core20](./source_pkg_noetic_core20/README.md) - Snap a ROS noetic package from source on core20.
 - [github_action](./github_action/README.md) - Build and publish a snap with GitHub Action.

--- a/source_pkg_jazzy_core24/CMakeLists.txt
+++ b/source_pkg_jazzy_core24/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.5)
+project(snapped_ros2_pkg)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+
+add_executable(snapped_ros2_pkg_node src/snapped_ros2_pkg_node.cpp)
+target_include_directories(snapped_ros2_pkg_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+ament_target_dependencies(snapped_ros2_pkg_node rclcpp geometry_msgs)
+
+install(TARGETS snapped_ros2_pkg_node
+  DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/source_pkg_jazzy_core24/README.md
+++ b/source_pkg_jazzy_core24/README.md
@@ -1,7 +1,7 @@
 # snapped_ros2_pkg
 ROS 2 Jazzy package, packed as a snap.
 
-The ROS package contains a node that simply publishes a `geometry_msgs::msg::Twist` on `fake_pose` containing random data.
+The ROS package contains a node that simply publishes a `geometry_msgs::msg::Twist` on `~/fake_pose` (resolved as `/snapped_ros2_pkg_node/fake_pose`) containing random data.
 ## How to generate the snap
 - `snapcraft`
 ## How to install the snap

--- a/source_pkg_jazzy_core24/README.md
+++ b/source_pkg_jazzy_core24/README.md
@@ -1,0 +1,10 @@
+# snapped_ros2_pkg
+ROS 2 Jazzy package, packed as a snap.
+
+The ROS package contains a node that simply publishes a `geometry_msgs::msg::Twist` on `fake_pose` containing random data.
+## How to generate the snap
+- `snapcraft`
+## How to install the snap
+- `sudo snap install snapped-ros2-pkg*.snap --dangerous`
+## How to run the snap
+- `snapped-ros2-pkg.snapped-ros2-launch`

--- a/source_pkg_jazzy_core24/config/config.yaml
+++ b/source_pkg_jazzy_core24/config/config.yaml
@@ -1,0 +1,3 @@
+snapped_ros2_pkg_node:
+  ros__parameters:
+    publish_rate: 1

--- a/source_pkg_jazzy_core24/launch/snapped.launch.py
+++ b/source_pkg_jazzy_core24/launch/snapped.launch.py
@@ -1,0 +1,21 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+import os
+
+def generate_launch_description():
+
+    config = os.path.join(
+        get_package_share_directory("snapped_ros2_pkg"), "config", "config.yaml"
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="snapped_ros2_pkg",
+                executable="snapped_ros2_pkg_node",
+                name="snapped_ros2_pkg_node",
+                parameters=[config],
+            )
+        ]
+    )

--- a/source_pkg_jazzy_core24/package.xml
+++ b/source_pkg_jazzy_core24/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>snapped_ros2_pkg</name>
+  <version>0.0.0</version>
+  <description>Basic ROS2 package packaged into a snap</description>
+  <maintainer email="guillaume.beuzeboc@canonical.com">gbeuzeboc</maintainer>
+  <license>GPLv3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/source_pkg_jazzy_core24/snap/snapcraft.yaml
+++ b/source_pkg_jazzy_core24/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: snapped-ros2-pkg
+version: '0.1'
+summary: Basic ROS 2 package snap
+description: |
+  Basic ROS 2 package snap with config and launchfile based on core24
+grade: stable
+confinement: strict
+base: core24
+
+parts:
+  snapped-ros2-pkg:
+    plugin: colcon
+    source: .
+    stage-packages: [ros-jazzy-ros2launch]
+
+apps:
+  snapped-ros2-launch:
+    command: opt/ros/jazzy/bin/ros2 launch snapped_ros2_pkg snapped.launch.py
+    plugs: [network, network-bind]
+    extensions: [ros2-jazzy]

--- a/source_pkg_jazzy_core24/src/snapped_ros2_pkg_node.cpp
+++ b/source_pkg_jazzy_core24/src/snapped_ros2_pkg_node.cpp
@@ -1,0 +1,31 @@
+#include <geometry_msgs/msg/twist.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/timer.hpp>
+
+using namespace std::chrono_literals;
+
+class NodeToSnap : public rclcpp::Node {
+public:
+  NodeToSnap() : rclcpp::Node{"snapped_ros2_pkg_node"} {
+    int publish_rate{1};
+    get_parameter("~/publish_rate", publish_rate);
+    m_publisher = create_publisher<geometry_msgs::msg::Twist>("~/fake_pose", 1);
+    m_timer = create_wall_timer(std::chrono::seconds{publish_rate}, [this]() {
+      geometry_msgs::msg::Twist twist;
+      twist.linear.x = static_cast<double>(std::rand() % 100 - 50);
+      twist.linear.y = static_cast<double>(std::rand() % 100 - 50);
+      m_publisher->publish(twist);
+    });
+  }
+
+private:
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr m_publisher;
+  rclcpp::TimerBase::SharedPtr m_timer;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<NodeToSnap>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
[hermes-agent]

## Summary
- Add a new example folder: `source_pkg_jazzy_core24`
- Copy the existing source package example layout and adapt it for ROS 2 Jazzy on core24
- Update top-level `README.md` examples list to include `source_pkg_jazzy_core24`

## Snap changes in the new example
- `base: core24`
- `extensions: [ros2-jazzy]`
- `stage-packages: [ros-jazzy-ros2launch]`
- launcher command path switched from `/opt/ros/humble/...` to `/opt/ros/jazzy/...`

## Test plan
- Local build attempt: `snapcraft pack` in `source_pkg_jazzy_core24`
- Result: blocked by environment issue in managed LXD instance (`snapd.service` fails to start in the base build instance)
- CI will run the repo workflow that builds and installs examples including this new one

Closes #22
