### PR TITLE
ci: core20 snaps require snapcraft 8.x/stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,26 @@ jobs:
     name: "Snap ${{ matrix.dir }}"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Determine snapcraft channel
+        id: snapcraft
+        run: |
+          if [[ "${{ matrix.dir }}" == *core18* ]]; then
+            echo "channel=7.x/stable" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.dir }}" == *core20* ]]; then
+            echo "channel=8.x/stable" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.dir }}" == *non_lts_galactic* ]]; then
+            echo "channel=8.x/stable" >> $GITHUB_OUTPUT
+          else
+            echo "channel=stable" >> $GITHUB_OUTPUT
+          fi
+
       - uses: snapcore/action-build@v1
         id: build-snap
         with:
           # Select the example we want to build
           path: "${{ matrix.dir }}"
-          snapcraft-channel: ${{ contains(matrix.dir, 'core18') && '7.x/stable' || contains(matrix.dir, 'core20') && '8.x/stable' || 'stable' }}
+          snapcraft-channel: ${{ steps.snapcraft.outputs.channel }}
 
       # Make sure the snap is installable
       - run: sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # Select the example we want to build
           path: "${{ matrix.dir }}"
-          snapcraft-channel: ${{ contains(matrix.dir, 'core18') && '7.x/stable' || 'stable' }}
+          snapcraft-channel: ${{ contains(matrix.dir, 'core18') && '7.x/stable' || contains(matrix.dir, 'core20') && '8.x/stable' || 'stable' }}
 
       # Make sure the snap is installable
       - run: sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}


### PR DESCRIPTION
Enforce using snapcraft 8 for core20 snaps.